### PR TITLE
Add migration plan for repo_lint to Rust binary

### DIFF
--- a/docs/ai-prompt/156/156-summary.md
+++ b/docs/ai-prompt/156/156-summary.md
@@ -1,0 +1,72 @@
+# Migrate `repo_lint` to a Self-Contained Rust Binary
+
+**Assignee:** @GitHubCopilot  
+**Labels:** enhancement, rust, migration, tooling  
+**Milestone:** v0.2.0 Tooling Overhaul  
+
+## Description
+
+You are an expert in software engineering, code migration, Rust development, repository management, and documentation analysis, with a focus on forensic-level audits and migration planning. You are tasked with a thorough, critical analysis of specific elements in this GitHub repository to develop a migration plan. Since you can access the repository directly from GitHub using your agent, review the entire repository structure, including all folders, subfolders, and files.
+
+Based on your comprehensive analysis, synthesize all findings into a detailed migration plan for transforming `repo_lint` into a self-contained Rust binary, addressing all specified requirements (embedded AST/linting, YAML configs with schema validation and IDE support) and additional considerations (e.g., performance, testing, distribution).
+
+Then, create a Markdown document in `docs/ai-prompt/156/` called `repo-lint-rust-binary-migration-plan.md`. Format this document as a properly formatted GitHub Issue, structured in a Milestone / Phase / Item / Sub-Item approach with checkboxes. Include a section near the bottom for adding "TODOs" and "Deferments".
+
+Provide your response in a clear, step-by-step format in this issue's comments, including any high-level rationale from your analysis. If you need to execute code or use tools to analyze files, do so as part of your process.
+
+## Milestones
+
+### Milestone 1: Repository Analysis and Planning
+- [ ] Phase 1.1: Thoroughly read and analyze **every Markdown document (.md file)** in the repository
+  - [ ] Item 1.1.1: Review files including, but not limited to, README.md, future-work.md, any docs/ folder contents, and all other .md files scattered throughout
+  - [ ] Item 1.1.2: Read each one in full, understanding the content, topics, relationships, technical details, and any implicit or explicit references to tools, features, or future plans
+  - [ ] Item 1.1.3: Take notes on overarching themes, inconsistencies, or gaps across all documents
+  - [ ] Item 1.1.4: Pay close attention to sections or content related to **CONTRACT ADHERENCE**, which is plainly laid out in many of these Markdown files
+    - [ ] Sub-Item 1.1.4.1: Identify and analyze all defined contracts (e.g., agent contracts, behavioral guidelines, or agreements)
+    - [ ] Sub-Item 1.1.4.2: Check for any contradictions between contracts across different files or sections
+    - [ ] Sub-Item 1.1.4.3: Flag inconsistencies, ambiguities, overlaps, or potential violations in contract definitions, enforcement, or adherence mechanisms
+
+- [ ] Phase 1.2: Focus on the tool named `repo_lint` within the repository
+  - [ ] Item 1.2.1: Locate and identify all associated components, such as code files, scripts, modules, configurations, dependencies, or documentation mentions
+  - [ ] Item 1.2.2: Conduct a forensic analysis of it to inform a migration plan
+  - [ ] Item 1.2.3: Be vicious and exhaustive in identifying challenges, requirements, and opportunities; call out **everything** relevant to migrating it to a completely self-contained Rust binary, including:
+    - [ ] Sub-Item 1.2.3.1: Current implementation details: Language(s) used, architecture, dependencies, AST parsing mechanisms, linting logic, configuration handling (e.g., current JSON usage), and integration points
+    - [ ] Sub-Item 1.2.3.2: Migration feasibility: Potential pitfalls in porting to Rust, such as replicating AST and linting for supported languages (e.g., Python, JavaScript), embedding required tools/libraries into the binary (e.g., using Rust crates like syn for Rust AST, tree-sitter for multi-language parsing)
+    - [ ] Sub-Item 1.2.3.3: Self-containment: Strategies to bundle all AST and linting tools within the binary (no external dependencies at runtime), including static linking and cross-compilation for platforms
+    - [ ] Sub-Item 1.2.3.4: Configuration overhaul: Plan to shift from JSON to YAML for external config files (e.g., linting rules, vectors), with schema validation (using Rust crates like schemars or validator); include generation of schema files (e.g., JSON Schema derived from YAML for IDE compatibility) to enable syntax checking, hints, and auto-complete in IDEs like JetBrains, PyCharm, VS Code, etc.
+    - [ ] Sub-Item 1.2.3.5: Performance and scalability: Improvements Rust could offer (e.g., speed, memory safety), but flag any trade-offs (e.g., compile times, learning curve)
+    - [ ] Sub-Item 1.2.3.6: Design considerations: CLI interface redesign, error handling, logging, usability, versioning for configs, backward compatibility
+    - [ ] Sub-Item 1.2.3.7: Dependencies and build: Rust equivalents for current deps, Cargo setup, build scripts for embedding assets
+    - [ ] Sub-Item 1.2.3.8: Testing: Unit/integration tests, coverage strategies for the binary
+    - [ ] Sub-Item 1.2.3.9: Distribution: Compilation to standalone executables, cross-platform support (Windows, macOS, Linux)
+    - [ ] Sub-Item 1.2.3.10: Contract adherence: How the migration impacts or enforces contracts from the Markdown files; include checks for contract contradictions in the tool's logic or configs
+    - [ ] Sub-Item 1.2.3.11: Any other aspects: Security implications, maintainability gains, potential over-engineering, integration with the broader repository, or unforeseen challenges (e.g., handling dynamic languages in a static binary)
+
+- [ ] Phase 1.3: Review the file `future-work.md` specifically
+  - [ ] Item 1.3.1: Extract and analyze **anything** related to the `repo_lint` tool, including planned features, improvements, bug fixes, integrations, or references
+  - [ ] Item 1.3.2: Cross-reference this with your analysis from Phase 1.2 to incorporate into the migration plan
+  - [ ] Item 1.3.3: Be vicious here too: Critique the future plans for feasibility in a Rust context, priority during migration, completeness, or potential pitfalls
+  - [ ] Item 1.3.4: Additionally, check for any contract adherence elements in these future plans, including potential contradictions with existing contracts
+
+### Milestone 2: Synthesis and Output Creation
+- [ ] Phase 2.1: Synthesize findings into migration plan
+  - [ ] Item 2.1.1: Address all specified requirements (embedded AST/linting, YAML configs with schema validation and IDE support)
+  - [ ] Item 2.1.2: Include additional considerations (e.g., performance, testing, distribution)
+
+- [ ] Phase 2.2: Create the Markdown document `repo-lint-rust-binary-migration-plan.md` in `docs/ai-prompt/156/`
+  - [ ] Item 2.2.1: Format it as a properly formatted GitHub Issue
+  - [ ] Item 2.2.2: Structure using Milestone / Phase / Item / Sub-Item approach with checkboxes
+    - [ ] Sub-Item 2.2.2.1: Include all steps for the migration (e.g., porting code, embedding tools, config overhaul)
+    - [ ] Sub-Item 2.2.2.2: Include implementations for all `repo_lint`-related items from `future-work.md`, adapted to Rust
+    - [ ] Sub-Item 2.2.2.3: Include specific handling for YAML schemas, validation, and IDE integration
+    - [ ] Sub-Item 2.2.2.4: Include fixes for any identified challenges, pitfalls, or contract issues
+    - [ ] Sub-Item 2.2.2.5: Provide clear descriptions, affected files/lines (if applicable), rationale, and step-by-step instructions (e.g., Rust crate selections, code snippets where helpful)
+    - [ ] Sub-Item 2.2.2.6: Include severity rankings (e.g., High, Medium, Low) for each item
+    - [ ] Sub-Item 2.2.2.7: Ensure it's actionable, scalable, and covers everything identified
+  - [ ] Item 2.2.3: Add a section near the bottom for "TODOs" and "Deferments"
+
+## TODOs
+- [ ] Add any unresolved analysis points here
+
+## Deferments
+- [ ] List any deferred tasks or future considerations here


### PR DESCRIPTION
Created a detailed migration plan for transforming `repo_lint` into a self-contained Rust binary, including analysis phases and milestones.